### PR TITLE
shell32.go: change the wrapper for Shell_NotifyIcon to obtain the las…

### DIFF
--- a/shell32.go
+++ b/shell32.go
@@ -522,11 +522,14 @@ func ShellExecute(hWnd HWND, verb *uint16, file *uint16, args *uint16, cwd *uint
 	return ret != 0
 }
 
-func Shell_NotifyIcon(dwMessage uint32, lpdata *NOTIFYICONDATA) bool {
-	ret, _, _ := syscall.Syscall(shell_NotifyIcon.Addr(), 2,
+func Shell_NotifyIcon(dwMessage uint32, lpdata *NOTIFYICONDATA) (err error) {
+	ret, _, e := syscall.Syscall(shell_NotifyIcon.Addr(), 2,
 		uintptr(dwMessage),
 		uintptr(unsafe.Pointer(lpdata)),
 		0)
 
-	return ret != 0
+	if ret == 0 {
+		err = windows.Errno(e)
+	}
+	return err
 }


### PR DESCRIPTION
…t error code from syscall

As outlined in https://github.com/tailscale/tailscale/issues/4133#issuecomment-1320351481, the syscall wrappers in this package should be obtaining the last error value directly from syscall, but are not.

This patch fixes the one for Shell_NotifyIcon in an effort to help diagnose its failures.

Updates https://github.com/tailscale/tailscale/issues/4133

Signed-off-by: Aaron Klotz <aaron@tailscale.com>