### PR TITLE
shell32.go: change Shell_NotifyIcon definition back to returning bool…

### DIFF
--- a/shell32.go
+++ b/shell32.go
@@ -532,16 +532,13 @@ func ShellExecute(hWnd HWND, verb *uint16, file *uint16, args *uint16, cwd *uint
 	return ret != 0
 }
 
-func Shell_NotifyIcon(dwMessage uint32, lpdata *NOTIFYICONDATA) (err error) {
-	ret, _, e := syscall.Syscall(shell_NotifyIcon.Addr(), 2,
+func Shell_NotifyIcon(dwMessage uint32, lpdata *NOTIFYICONDATA) bool {
+	ret, _, _ := syscall.Syscall(shell_NotifyIcon.Addr(), 2,
 		uintptr(dwMessage),
 		uintptr(unsafe.Pointer(lpdata)),
 		0)
 
-	if ret == 0 {
-		err = windows.Errno(e)
-	}
-	return err
+	return int32(ret) != 0
 }
 
 func Shell_NotifyIconGetRect(identifier *NOTIFYICONIDENTIFIER, iconLocation *RECT) HRESULT {


### PR DESCRIPTION
… instead of error

Even though Windows docs do not make any mention of this API returning an error code, we tried anyway for the purposes of diagnosing another bug. It never really helped, and eventually we did fix that bug (the API was being called off the UI goroutine). Let's revert the definition back to match its documentation so that we don't get thrown off by potentially bogus error codes.

This is #cleanup.